### PR TITLE
Added plain text toggle button

### DIFF
--- a/app/views/shared/editor_engines/_yui_rich_editor.html.erb
+++ b/app/views/shared/editor_engines/_yui_rich_editor.html.erb
@@ -31,7 +31,7 @@
             //  Used for dup show() method to fix file/image upload buttons not initializing properly
             var editorInitialized = false;
             if ($('textarea#' + id)) {
-                newEditor = new YAHOO.widget.Editor(id, {
+                newEditor = window[id + '_editor'] = new YAHOO.widget.Editor(id, {
                     height: '350px',
                     width: 'auto',
                     animate: true,
@@ -131,6 +131,7 @@
                 });
 
                 newEditor.addListener('editorContentLoaded', function() {
+                    newEditor = window[id + '_editor'];
                     $(".yui-toolbar-imageUpload").upload({
                         name: 'content_image[attachment]',
                         action: '/content_images',
@@ -166,7 +167,8 @@
                         }
                     });
                     if( editorInitialized == false) {
-                        newEditor.show();
+                        if( newEditor.getEditorHTML() != "" )
+                            newEditor.show();
                         editorInitialized = true;
                     }
                 });
@@ -177,6 +179,8 @@
                 if( document.getElementById(id + '_toggleEditor') != undefined ) {
                   var Dom = YAHOO.util.Dom,        
                   Event = YAHOO.util.Event;
+
+                  newEditor = window[id + '_editor'];
                                   
                   var _button = new YAHOO.widget.Button(id + '_toggleEditor');   
                   _button.addClass('toggleEditor');
@@ -188,8 +192,8 @@
                       if (state == 'on') {
                           state = 'off';   
                           newEditor.saveHTML();  
-                          var stripHTML = /<\S[^><]*>/g;   
-                          newEditor.get('textarea').value = newEditor.get('textarea').value.replace(/<br>/gi, '\n').replace(stripHTML, '');
+                          //var stripHTML = /<\S[^><]*>/g;   
+                          //newEditor.get('textarea').value = newEditor.get('textarea').value.replace(/<br>/gi, '\n').replace(stripHTML, '');
                         
                           var fc = newEditor.get('element').previousSibling,        
                               el = newEditor.get('element');
@@ -215,7 +219,7 @@
                           Dom.setStyle(el, 'position', 'absolute');   
                           newEditor.get('element_cont').addClass('yui-editor-container');   
                           newEditor._setDesignMode('on');   
-                          newEditor.setEditorHTML(newEditor.get('textarea').value.replace(/\n/g, '<br>'));   
+                          newEditor.setEditorHTML(newEditor.get('textarea').value);   
                       }        
                   });
                 }

--- a/app/views/shared/editor_engines/_yui_rich_editor.html.erb
+++ b/app/views/shared/editor_engines/_yui_rich_editor.html.erb
@@ -172,7 +172,7 @@
                 var Dom = YAHOO.util.Dom,        
                 Event = YAHOO.util.Event;
                                   
-                var _button = new YAHOO.widget.Button(id + 'toggleEditor');   
+                var _button = new YAHOO.widget.Button(id + '_toggleEditor');   
                 _button.addClass('toggleEditor');
                                                                       
                 var state = 'on';

--- a/app/views/shared/editor_engines/_yui_rich_editor.html.erb
+++ b/app/views/shared/editor_engines/_yui_rich_editor.html.erb
@@ -29,7 +29,7 @@
         var ids = [<%= ids.map{|id| "'#{id}'"}.join(', ') %>];
         $.each(ids, function(index, id) {
             if ($('textarea#' + id)) {
-                window[id + '_editor'] = new YAHOO.widget.Editor(id, {
+                newEditor = new YAHOO.widget.Editor(id, {
                     height: '350px',
                     width: 'auto',
                     animate: true,
@@ -128,7 +128,7 @@
                     }
                 });
 
-                window[id + '_editor'].addListener('editorContentLoaded', function() {
+                newEditor.addListener('editorContentLoaded', function() {
                     $(".yui-toolbar-imageUpload").upload({
                         name: 'content_image[attachment]',
                         action: '/content_images',
@@ -140,7 +140,7 @@
                         },
                         onComplete: function(image_src) {
                             var img_html = "<img src='" + image_src + "'/>";
-                            window[id + '_editor'].execCommand('inserthtml', img_html);
+                            newEditor.execCommand('inserthtml', img_html);
                             $(".editor-mask-container").removeClass("active");
                         }
                     });
@@ -160,13 +160,13 @@
                             $(".editor-mask-container").removeClass("active");
                             var file_name = prompt('<%= t("editor.enter_file_name") %>', file_name_original);
                             var link_html = "<a href='" + file_url + "'/>" + file_name + "</a>";
-                            window[id + '_editor'].execCommand('inserthtml', link_html);
+                            newEditor.execCommand('inserthtml', link_html);
                         }
                     });
                 });
 
-                window[id + '_editor'].render();
-                window[id + '_editor'].show();
+                newEditor.render();
+                newEditor.show();
 
                 // Add Toggle Button for plain text view
                 var Dom = YAHOO.util.Dom,        
@@ -176,22 +176,21 @@
                 _button.addClass('toggleEditor');
                                                                       
                 var state = 'on';
-                var myEditor = window[id + '_editor'];
 
                 _button.on('click', function(ev) {
                     Event.stopEvent(ev);   
                     if (state == 'on') {
                         state = 'off';   
-                        myEditor.saveHTML();  
+                        newEditor.saveHTML();  
                         var stripHTML = /<\S[^><]*>/g;   
-                        myEditor.get('textarea').value = myEditor.get('textarea').value.replace(/<br>/gi, '\n').replace(stripHTML, '');
+                        newEditor.get('textarea').value = newEditor.get('textarea').value.replace(/<br>/gi, '\n').replace(stripHTML, '');
                         
-                        var fc = myEditor.get('element').previousSibling,        
-                            el = myEditor.get('element');
+                        var fc = newEditor.get('element').previousSibling,        
+                            el = newEditor.get('element');
                         Dom.setStyle(fc, 'position', 'absolute');   
                         Dom.setStyle(fc, 'top', '-9999px');   
                         Dom.setStyle(fc, 'left', '-9999px');   
-                        myEditor.get('element_cont').removeClass('yui-editor-container');   
+                        newEditor.get('element_cont').removeClass('yui-editor-container');   
                         Dom.setStyle(el, 'visibility', 'visible');   
                         Dom.setStyle(el, 'top', '');   
                         Dom.setStyle(el, 'left', '');   
@@ -199,8 +198,8 @@
                     } else {       
                         state = 'on';   
 
-                        var fc = myEditor.get('element').previousSibling,        
-                        el = myEditor.get('element');   
+                        var fc = newEditor.get('element').previousSibling,        
+                        el = newEditor.get('element');   
                         Dom.setStyle(fc, 'position', 'static');   
                         Dom.setStyle(fc, 'top', '0');   
                         Dom.setStyle(fc, 'left', '0');   
@@ -208,9 +207,9 @@
                         Dom.setStyle(el, 'top', '-9999px');   
                         Dom.setStyle(el, 'left', '-9999px');   
                         Dom.setStyle(el, 'position', 'absolute');   
-                        myEditor.get('element_cont').addClass('yui-editor-container');   
-                        myEditor._setDesignMode('on');   
-                        myEditor.setEditorHTML(myEditor.get('textarea').value.replace(/\n/g, '<br>'));   
+                        newEditor.get('element_cont').addClass('yui-editor-container');   
+                        newEditor._setDesignMode('on');   
+                        newEditor.setEditorHTML(newEditor.get('textarea').value.replace(/\n/g, '<br>'));   
                     }        
                 });
                 // End Toggle Button

--- a/app/views/shared/editor_engines/_yui_rich_editor.html.erb
+++ b/app/views/shared/editor_engines/_yui_rich_editor.html.erb
@@ -166,6 +166,56 @@
                 });
 
                 window[id + '_editor'].render();
+                window[id + '_editor'].show();
+
+                // Add Toggle Button for plain text view
+                var Dom = YAHOO.util.Dom,        
+                Event = YAHOO.util.Event;
+                                  
+                var _button = new YAHOO.widget.Button(id + 'toggleEditor');   
+                _button.addClass('toggleEditor');
+                                                                      
+                var state = 'on';
+                                                                                        
+                var myEditor = window[id + '_editor'];
+                myEditor.show();
+                                                                                                                            
+                _button.on('click', function(ev) {
+                    Event.stopEvent(ev);   
+                    if (state == 'on') {
+                        state = 'off';   
+                        myEditor.saveHTML();  
+                        var stripHTML = /<\S[^><]*>/g;   
+                        myEditor.get('textarea').value = myEditor.get('textarea').value.replace(/<br>/gi, '\n').replace(stripHTML, '');
+                        
+                        var fc = myEditor.get('element').previousSibling,        
+                            el = myEditor.get('element');
+                        Dom.setStyle(fc, 'position', 'absolute');   
+                        Dom.setStyle(fc, 'top', '-9999px');   
+                        Dom.setStyle(fc, 'left', '-9999px');   
+                        myEditor.get('element_cont').removeClass('yui-editor-container');   
+                        Dom.setStyle(el, 'visibility', 'visible');   
+                        Dom.setStyle(el, 'top', '');   
+                        Dom.setStyle(el, 'left', '');   
+                        Dom.setStyle(el, 'position', 'static');   
+                    } else {       
+                        state = 'on';   
+
+                        var fc = myEditor.get('element').previousSibling,        
+                        el = myEditor.get('element');   
+                        Dom.setStyle(fc, 'position', 'static');   
+                        Dom.setStyle(fc, 'top', '0');   
+                        Dom.setStyle(fc, 'left', '0');   
+                        Dom.setStyle(el, 'visibility', 'hidden');   
+                        Dom.setStyle(el, 'top', '-9999px');   
+                        Dom.setStyle(el, 'left', '-9999px');   
+                        Dom.setStyle(el, 'position', 'absolute');   
+                        myEditor.get('element_cont').addClass('yui-editor-container');   
+                        myEditor._setDesignMode('on');   
+                        myEditor.setEditorHTML(myEditor.get('textarea').value.replace(/\n/g, '<br>'));   
+                    }        
+                });
+                // End Toggle Button
             }
         });
     });

--- a/app/views/shared/editor_engines/_yui_rich_editor.html.erb
+++ b/app/views/shared/editor_engines/_yui_rich_editor.html.erb
@@ -28,6 +28,8 @@
         var myConfig = { dompath: true };
         var ids = [<%= ids.map{|id| "'#{id}'"}.join(', ') %>];
         $.each(ids, function(index, id) {
+            //  Used for dup show() method to fix file/image upload buttons not initializing properly
+            var editorInitialized = false;
             if ($('textarea#' + id)) {
                 newEditor = new YAHOO.widget.Editor(id, {
                     height: '350px',
@@ -163,55 +165,60 @@
                             newEditor.execCommand('inserthtml', link_html);
                         }
                     });
+                    if( editorInitialized == false) {
+                        newEditor.show();
+                        editorInitialized = true;
+                    }
                 });
 
                 newEditor.render();
-                newEditor.show();
 
                 // Add Toggle Button for plain text view
-                var Dom = YAHOO.util.Dom,        
-                Event = YAHOO.util.Event;
+                if( document.getElementById(id + '_toggleEditor') != undefined ) {
+                  var Dom = YAHOO.util.Dom,        
+                  Event = YAHOO.util.Event;
                                   
-                var _button = new YAHOO.widget.Button(id + '_toggleEditor');   
-                _button.addClass('toggleEditor');
+                  var _button = new YAHOO.widget.Button(id + '_toggleEditor');   
+                  _button.addClass('toggleEditor');
                                                                       
-                var state = 'on';
+                  var state = 'on';
 
-                _button.on('click', function(ev) {
-                    Event.stopEvent(ev);   
-                    if (state == 'on') {
-                        state = 'off';   
-                        newEditor.saveHTML();  
-                        var stripHTML = /<\S[^><]*>/g;   
-                        newEditor.get('textarea').value = newEditor.get('textarea').value.replace(/<br>/gi, '\n').replace(stripHTML, '');
+                  _button.on('click', function(ev) {
+                      Event.stopEvent(ev);   
+                      if (state == 'on') {
+                          state = 'off';   
+                          newEditor.saveHTML();  
+                          var stripHTML = /<\S[^><]*>/g;   
+                          newEditor.get('textarea').value = newEditor.get('textarea').value.replace(/<br>/gi, '\n').replace(stripHTML, '');
                         
-                        var fc = newEditor.get('element').previousSibling,        
-                            el = newEditor.get('element');
-                        Dom.setStyle(fc, 'position', 'absolute');   
-                        Dom.setStyle(fc, 'top', '-9999px');   
-                        Dom.setStyle(fc, 'left', '-9999px');   
-                        newEditor.get('element_cont').removeClass('yui-editor-container');   
-                        Dom.setStyle(el, 'visibility', 'visible');   
-                        Dom.setStyle(el, 'top', '');   
-                        Dom.setStyle(el, 'left', '');   
-                        Dom.setStyle(el, 'position', 'static');   
-                    } else {       
-                        state = 'on';   
+                          var fc = newEditor.get('element').previousSibling,        
+                              el = newEditor.get('element');
+                          Dom.setStyle(fc, 'position', 'absolute');   
+                          Dom.setStyle(fc, 'top', '-9999px');   
+                          Dom.setStyle(fc, 'left', '-9999px');   
+                          newEditor.get('element_cont').removeClass('yui-editor-container');   
+                          Dom.setStyle(el, 'visibility', 'visible');   
+                          Dom.setStyle(el, 'top', '');   
+                          Dom.setStyle(el, 'left', '');   
+                          Dom.setStyle(el, 'position', 'static');   
+                      } else {       
+                          state = 'on';   
 
-                        var fc = newEditor.get('element').previousSibling,        
-                        el = newEditor.get('element');   
-                        Dom.setStyle(fc, 'position', 'static');   
-                        Dom.setStyle(fc, 'top', '0');   
-                        Dom.setStyle(fc, 'left', '0');   
-                        Dom.setStyle(el, 'visibility', 'hidden');   
-                        Dom.setStyle(el, 'top', '-9999px');   
-                        Dom.setStyle(el, 'left', '-9999px');   
-                        Dom.setStyle(el, 'position', 'absolute');   
-                        newEditor.get('element_cont').addClass('yui-editor-container');   
-                        newEditor._setDesignMode('on');   
-                        newEditor.setEditorHTML(newEditor.get('textarea').value.replace(/\n/g, '<br>'));   
-                    }        
-                });
+                          var fc = newEditor.get('element').previousSibling,        
+                          el = newEditor.get('element');   
+                          Dom.setStyle(fc, 'position', 'static');   
+                          Dom.setStyle(fc, 'top', '0');   
+                          Dom.setStyle(fc, 'left', '0');   
+                          Dom.setStyle(el, 'visibility', 'hidden');   
+                          Dom.setStyle(el, 'top', '-9999px');   
+                          Dom.setStyle(el, 'left', '-9999px');   
+                          Dom.setStyle(el, 'position', 'absolute');   
+                          newEditor.get('element_cont').addClass('yui-editor-container');   
+                          newEditor._setDesignMode('on');   
+                          newEditor.setEditorHTML(newEditor.get('textarea').value.replace(/\n/g, '<br>'));   
+                      }        
+                  });
+                }
                 // End Toggle Button
             }
         });

--- a/app/views/shared/editor_engines/_yui_rich_editor.html.erb
+++ b/app/views/shared/editor_engines/_yui_rich_editor.html.erb
@@ -176,10 +176,8 @@
                 _button.addClass('toggleEditor');
                                                                       
                 var state = 'on';
-                                                                                        
                 var myEditor = window[id + '_editor'];
-                myEditor.show();
-                                                                                                                            
+
                 _button.on('click', function(ev) {
                     Event.stopEvent(ev);   
                     if (state == 'on') {


### PR DESCRIPTION
I've added an optional toggle button functionality that will apply any button on the page with an id of `id + '_toggleButton'` similar to how the editor is applied to every text field based on their id.

This allows users to toggle the visibility of the editor, and allows users to edit the content in plain text.
