### PR TITLE
Enable rich editor based on field name mask rather than id

### DIFF
--- a/app/views/shared/editor_engines/_tiny_mce.html.erb
+++ b/app/views/shared/editor_engines/_tiny_mce.html.erb
@@ -5,19 +5,24 @@
     $(function() {
         var myConfig = { dompath: true };
         var ids = [<%= ids.map{|id| "'#{id}'"}.join(', ') %>]
-        $.each(ids, function(index, id) {
-            if ($('textarea#' + id).length) {
+        $('textarea').filter(function() {
+            for (var i = 0; i < ids.length; i++) {
+                if(this.name.match('^'+ids[i])) return true;
+            }
+            return false;
+        }).each(function() {
                 tinyMCE.init({
                     mode : "exact",
-                    elements : id,
+                    elements : this.name,
                     theme : "advanced",
                     language : '<%= I18n.locale.to_s.downcase %>',
                     skin : "o2k7",
-                    plugins : "safari,style,layer,table,advhr,advimage,inlinepopups,insertdatetime,preview,media,searchreplace,contextmenu,paste,directionality,fullscreen,noneditable,visualchars,nonbreaking,xhtmlxtras,template",
-
+                    width: this,
+                    skin_variant : "silver",
+                    plugins : "safari,style,table,advhr,advimage,preview,media,searchreplace,contextmenu,paste,fullscreen,noneditable,visualchars,nonbreaking,xhtmlxtras,template",
                     // Theme options
-                    theme_advanced_buttons1 : "cut,copy,paste,pastetext,pasteword,|,search,replace,|,undo,redo,|,link,unlink,anchor,image,cleanup,help,code,|,insertdate,inserttime,preview,|,fullscreen,|,charmap,media,advhr,|,visualchars,nonbreaking,blockquote",
-                    theme_advanced_buttons2 : "bold,italic,underline,strikethrough,|,justifyleft,justifycenter,justifyright,justifyfull,|,sub,sup,|,bullist,numlist,|,outdent,indent,blockquote,|,styleselect,formatselect,fontselect,fontsizeselect,|,forecolor,backcolor",
+                    theme_advanced_buttons1 : "cut,copy,paste,pastetext,pasteword,|,search,replace,|,undo,redo,|,link,unlink,anchor,image,cleanup,code,|,preview,|,fullscreen,|,charmap,media,advhr,|,visualchars,nonbreaking,blockquote,",
+                    theme_advanced_buttons2 : "bold,italic,underline,strikethrough,|,justifyleft,justifycenter,justifyright,justifyfull,|,sub,sup,|,bullist,numlist,|,outdent,indent,blockquote,|,styleselect,formatselect|,forecolor,backcolor",
                     theme_advanced_buttons3 : "tablecontrols,|,hr,removeformat,visualaid",
                     theme_advanced_buttons4 : "",
                     theme_advanced_toolbar_location : "top",
@@ -34,7 +39,6 @@
                     external_image_list_url : "js/image_list.js",
                     media_external_list_url : "js/media_list.js",
                 });
-            }
         });
     });
 </script>

--- a/app/views/shared/editor_engines/_wym_editor.html.erb
+++ b/app/views/shared/editor_engines/_wym_editor.html.erb
@@ -2,7 +2,15 @@
 
 <script type="text/javascript">
   $(function() {
-      var ids = [<%= ids.map{|id| "'textarea##{id}'"}.join(', ') %>]
-      $(ids.join(', ')).wymeditor({ lang: '<%= I18n.locale.to_s.downcase %>', skin: 'compact' });
+      var ids = [<%= ids.map{|id| "'#{id}'"}.join(', ') %>]
+      
+      $('textarea').filter(function() {
+          for (var i = 0; i < ids.length; i++) {
+              if(this.name.match('^'+ids[i])) return true;
+          }
+          return false;
+      }).each(function() {
+          $(this).wymeditor({ lang: '<%= I18n.locale.to_s.downcase %>', skin: 'compact' });
+      });
   });
 </script>

--- a/app/views/shared/editor_engines/_yui_rich_editor.html.erb
+++ b/app/views/shared/editor_engines/_yui_rich_editor.html.erb
@@ -28,11 +28,16 @@
         var Dom = YAHOO.util.Dom,
   	        Event = YAHOO.util.Event;
         var myConfig = { dompath: true };
-        var ids = [<%= ids.map{|id| "'#{id}'"}.join(', ') %>];
-        $.each(ids, function(index, id) {
-            if ($('textarea#' + id).length) {
+        var ids = [<%= ids.map{|id| "'#{id}'"}.join(', ') %>]
+            $('textarea').filter(function() {
+                for (var i = 0; i < ids.length; i++) {
+                    if(this.name.match('^'+ids[i])) return true;
+                }
+                return false;
+            }).each(function() {
                 var state = 'off';
-                var newEditor = window[id + '_editor'] = new YAHOO.widget.Editor(id, {
+
+                var newEditor = window[this.id + '_editor'] = new YAHOO.widget.Editor(this.id, {
                     height: '350px',
                     width: 'auto',
                     animate: true,
@@ -219,7 +224,6 @@
           	        }, this, true);
                 }, newEditor, true);
                 newEditor.render();
-            }
         });
     });
 </script>


### PR DESCRIPTION
Changed behavior of editor binding to be able to enable editor based on textarea name mask rather than id. This makes spree_editor work with spree_simple_product_translations (this extension adds product_description textareas for each enabled languages, so bind by ID doesn't work anymore).

Also I modified default set of instruments, so I'm not sure you want this in master branch, it's up to you to decide.
